### PR TITLE
Fix Blueprint.new handling of caching when the wrapped object responds t...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## next
 
+* Fix `Blueprint.new` handling of caching when the wrapped object responds to `identity_map`, but does not have one set.
 
 ## 1.3.1
 

--- a/lib/praxis-blueprints/blueprint.rb
+++ b/lib/praxis-blueprints/blueprint.rb
@@ -35,7 +35,7 @@ module Praxis
       if @@caching_enabled && decorators.nil?
         key = object
 
-        cache = if object.respond_to?(:identity_map)
+        cache = if object.respond_to?(:identity_map) && object.identity_map
           object.identity_map.blueprint_cache[self]
         else
           self.cache


### PR DESCRIPTION
...o identity_map, but does not have one set.