### PR TITLE
Support for rendering custom views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 * Fix `Blueprint.new` handling of caching when the wrapped object responds to `identity_map`, but does not have one set.
 * Undefine JRuby package helper methods in `Model` (org, java...)
+* Added support for rendering custom views
+  * Internally, a `View` object can now be dumped passing a `:fields` option (which is a hash, that can recursively will define which sub-attributes to render along the way). See [this spec](https://github.com/rightscale/praxis-blueprints/blob/master/spec/praxis-blueprints/blueprint_spec.rb) for an example.
+  * `Blueprints` will also accept the `:fields` option (with the same hash syntax), but it will also accept an array to imply the list of top-level attributes to render (when recursion is not necessary)
 
 ## 1.3.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Added support for rendering custom views
   * Internally, a `View` object can now be dumped passing a `:fields` option (which is a hash, that can recursively will define which sub-attributes to render along the way). See [this spec](https://github.com/rightscale/praxis-blueprints/blob/master/spec/praxis-blueprints/blueprint_spec.rb) for an example.
   * `Blueprints` will also accept the `:fields` option (with the same hash syntax), but it will also accept an array to imply the list of top-level attributes to render (when recursion is not necessary)
+  * Caching of rendered blueprints will continue to work if the view is re-rendered with equivalent `:fields`
 
 ## 1.3.1
 

--- a/spec/praxis-blueprints/blueprint_spec.rb
+++ b/spec/praxis-blueprints/blueprint_spec.rb
@@ -350,6 +350,23 @@ describe Praxis::Blueprint do
       end
     end
 
+    context 'using the `fields` option' do
+      context 'as a hash' do
+        subject(:output) { person.render(view_name, fields: {address: { state: nil} } ) }
+        it 'should only have the address rendered' do
+          output.keys.should == [:address]
+        end
+        it 'address should only have state' do
+          output[:address].keys.should == [:state]
+        end
+      end
+      context 'as a simple array' do
+        subject(:output) { person.render(view_name, fields: [:address] ) }
+        it 'accepts it as the list of top-level attributes to be rendered' do
+          output.keys.should == [:address]
+        end
+      end
+    end
   end
 
 end

--- a/spec/praxis-blueprints/blueprint_spec.rb
+++ b/spec/praxis-blueprints/blueprint_spec.rb
@@ -321,7 +321,49 @@ describe Praxis::Blueprint do
   context '#render' do
     let(:person) { Person.example }
     let(:view_name) { :default }
-    subject(:output) { person.render(view_name) }
+    let(:render_opts) { {} }
+    subject(:output) { person.render(view_name, render_opts) }
+
+    context 'caches rendered views' do
+      it 'in the instance, by view name'  do
+        person.instance_variable_get(:@rendered_views)[view_name].should be_nil
+        person.render(view_name)
+        cached = person.instance_variable_get(:@rendered_views)[view_name]
+        cached.should_not be_nil
+      end
+
+      it 'and does not re-render a view if one is already cached'  do
+        rendered1 = person.render(view_name)
+        rendered2 = person.render(view_name)
+        rendered1.should be(rendered2)
+      end
+
+      context 'even when :fields are specified' do
+        let(:render_opts) { {fields: {email: nil, age: nil, address: {street: nil, state: nil}}} }
+
+        it 'caches the output in a different key than just the view_name' do
+          plain_view_render = person.render(view_name)
+          fields_render = person.render(view_name, render_opts)
+          plain_view_render.should_not be(fields_render)
+        end
+
+        it 'it still caches the object if rendered for the same fields'  do
+          rendered1 = person.render(view_name, render_opts)
+          rendered2 = person.render(view_name, render_opts)
+          rendered1.should be(rendered2)
+        end
+
+        it 'it still caches the object if rendered for the same fields (even from an "equivalent" hash)'  do
+          rendered1 = person.render(view_name, render_opts)
+
+          equivalent_render_opts = { fields: {age: nil, address: {state: nil, street: nil}, email: nil} }
+          rendered2 = person.render(view_name, equivalent_render_opts)
+
+          rendered1.should be(rendered2)
+        end
+      end
+
+    end
 
     context 'with a sub-attribute that is a blueprint' do
 

--- a/spec/praxis-blueprints/view_spec.rb
+++ b/spec/praxis-blueprints/view_spec.rb
@@ -12,8 +12,8 @@ describe Praxis::View do
       attribute :address, view: :state
     end
   end
-
-  subject(:output) { view.to_hash(person) }
+  let(:dumping_options){ {} }
+  subject(:output) { view.to_hash(person, dumping_options ) }
 
 
   it 'can generate examples' do
@@ -53,7 +53,22 @@ describe Praxis::View do
         output.key?(:age).should_not be(true)
         output.key?(:address).should_not be(true)
       end
+
+      context 'and custom field rendering' do
+        let(:data) { {name: 'Bob', email: 'bob@acme.org', age: 50 } }
+
+        context 'renders only the specified fields that have values' do
+          let(:dumping_options){ { fields: {name: nil, email: nil} } }
+          its(:keys){ should == [:name, :email] }
+        end
+
+        context 'renders only the specified fields excluding nil valued ones' do
+          let(:dumping_options){ { fields: {name: nil, address: nil} } }
+          its(:keys){ should == [:name] }
+        end
+      end
     end
+
 
     context 'with include_nil: true' do
       let(:view) do
@@ -64,8 +79,6 @@ describe Praxis::View do
           attribute :address
         end
       end
-
-      subject(:output) { view.to_hash(person) }
 
       it 'includes attributes with nil values' do
         output.key?(:email).should be(true)
@@ -78,9 +91,16 @@ describe Praxis::View do
         output[:age].should be(nil)
       end
 
+      context 'and custom field rendering' do
+        let(:data) { {name: 'Bob', email: 'bob@acme.org', age: 50 } }
+
+        context 'renders only the specified fields including nil valued' do
+          let(:dumping_options){ { fields: {name: nil, address: nil}} }
+          its(:keys){ should == [:name,:address] }
+        end
+      end
     end
 
-  
   end
 
 
@@ -199,6 +219,21 @@ describe Praxis::View do
 
 
       it { should eq expected_output }
+
+      context 'using the fields option' do
+        let(:dumping_options){ { fields: {name: nil, address: {state: nil} } } }
+
+        let(:expected_output) do
+          {
+            :name => person.name,
+            :address => {
+              :state => address.state
+            }
+          }
+        end
+
+        it { should eq expected_output }
+      end
 
     end
 


### PR DESCRIPTION
* Internally, a `View` object can now be dumped passing a `:fields` option (which is a hash, that can recursively will define which sub-attributes to render along the way). 
* `Blueprints` will also accept the `:fields` option (with the same hash syntax), but it will also accept an array to imply the list of top-level attributes to render (when recursion is not necessary)


Signed-off-by: Josep M. Blanquer <blanquer@rightscale.com>