### PR TITLE
Tl 465 add codecoverage and gemnasium

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
 cache: bundler
+sudo: false
 rvm:
   - 2.1.2
   - 2.2.2

--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
-# Praxis Blueprints [![TravisCI][travis-img-url]][travis-ci-url] 
+# Praxis Blueprints [![TravisCI][travis-img-url]][travis-ci-url] [![Coverage Status][coveralls-img-url]][coveralls-url] [![Dependency Status][gemnasium-img-url]][gemnasium-url]
 
 [travis-img-url]:https://travis-ci.org/rightscale/praxis-blueprints.svg?branch=master
 [travis-ci-url]:https://travis-ci.org/rightscale/praxis-blueprints
+[coveralls-img-url]:https://coveralls.io/repos/rightscale/praxis-blueprints/badge.svg?branch=master&service=github
+[coveralls-url]:https://coveralls.io/github/rightscale/praxis-blueprints?branch=master
+[gemnasium-img-url]:https://gemnasium.com/rightscale/praxis-blueprints.svg
+[gemnasium-url]:https://gemnasium.com/rightscale/praxis-blueprints
 
 
 Praxis Blueprints is a library that allows for defining a reusable class structures that has a set of typed attributes and a set of views with which to render them. Instantiations of Blueprints resemble ruby Structs which respond to methods of the attribute names. Rendering is format-agnostic in that

--- a/praxis-blueprints.gemspec
+++ b/praxis-blueprints.gemspec
@@ -35,4 +35,5 @@ it results in a structured hash instead of an encoded string. Blueprints can aut
   spec.add_development_dependency(%q<pry-byebug>, ["~> 1"])
   spec.add_development_dependency(%q<pry-stack_explorer>, ["~> 0"])
   spec.add_development_dependency(%q<fuubar>, ["~> 1"])
+  spec.add_development_dependency(%q<coveralls>)
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,6 @@
+require 'coveralls'
+Coveralls.wear!
+
 Encoding.default_external = Encoding::UTF_8
 
 require 'rubygems'


### PR DESCRIPTION
This add code coverage stats and Coveralls and Gemnasium badges on the README.

`sudo: false` allows the TravisCI build to run in docker, so it is much faster to start.