### PR TITLE
Lazy initialize the member_view contents of a CollectionView

### DIFF
--- a/lib/praxis-blueprints/collection_view.rb
+++ b/lib/praxis-blueprints/collection_view.rb
@@ -5,8 +5,16 @@ module Praxis
       super(name,schema)
 
       if member_view
-        @contents = member_view.contents.clone
+        @_lazy_view = member_view
       end
+    end
+
+    def contents
+      if @_lazy_view
+        @contents = @_lazy_view.contents.clone
+        @_lazy_view = nil
+      end
+      super
     end
 
     def example(context=Attributor::DEFAULT_ROOT_CONTEXT)

--- a/spec/praxis-blueprints/collection_view_spec.rb
+++ b/spec/praxis-blueprints/collection_view_spec.rb
@@ -32,6 +32,19 @@ describe Praxis::CollectionView do
     it 'gets the proper contents' do
       collection_view.contents.should eq member_view.contents
     end
+
+    context 'lazy initializes its contents' do
+
+      it 'so it will not call contents until it is first needed' do
+        member_view.stub(:contents){ raise 'No!' }
+        expect{ collection_view.name }.to_not raise_error
+      end
+      it 'when contents is needed, it will clone it from the member_view' do
+        # Twice is because we're callong member_view.contents for the right side of the equality
+        expect(member_view).to receive(:contents).twice.and_call_original
+        collection_view.contents.should eq member_view.contents
+      end
+    end
   end
 
   context 'creating with a set of attributes defined in a block' do

--- a/spec/praxis-blueprints/view_spec.rb
+++ b/spec/praxis-blueprints/view_spec.rb
@@ -72,6 +72,24 @@ describe Praxis::View do
         end
       end
 
+      context 'that reference the enclosing view' do
+        let(:view) { Person.views.fetch(:self_referencing) }
+        context 'for non-collection attributes' do
+          it 'the view points exactly to parent view' do
+            contents[:myself].should be_kind_of(Praxis::View)
+            contents[:myself].should be(view)
+            contents[:myself].contents.should eq(view.contents)
+          end
+        end
+        context 'for collection attributes' do
+          it 'creates the sub-CollectionViews with a member view with the same contents of the parent' do
+            contents[:friends].should be_kind_of(Praxis::CollectionView)
+            contents[:friends].contents.should eq(view.contents)
+            contents[:friends].contents.keys.should match_array([:myself,:friends])
+          end
+        end
+
+      end
     end
 
   end

--- a/spec/support/spec_blueprints.rb
+++ b/spec/support/spec_blueprints.rb
@@ -20,6 +20,8 @@ class Person < Praxis::Blueprint
     attribute :tags, Attributor::Collection.of(String)
     attribute :href, String
     attribute :alive, Attributor::Boolean, default: true
+    attribute :myself, Person
+    attribute :friends, Attributor::Collection.of(Person)
   end
 
   view :default do
@@ -31,6 +33,11 @@ class Person < Praxis::Blueprint
 
   view :circular do
     attribute :address, view: :circular
+  end
+
+  view :self_referencing do
+    attribute :myself, view: :self_referencing
+    attribute :friends, view: :self_referencing
   end
 
   view :current do


### PR DESCRIPTION
This allows defining views, that contain sub attributes which can still reference the enclosing (and therefore still not fully defined) view.
 
closes #24

Signed-off-by: Josep M. Blanquer <blanquer@rightscale.com>