### PR TITLE
Call object.dump in rendered for Dumpable instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## next
 
-* Ensure we call `object.dump` in Renderer when dumping a Attributor::Hash or collection of Attributor::Hash if no subfields were selected.
+* Ensure we call `object.dump` in Renderer when fully dumping an instance (or array of instances) that have the Attributor::Dumpable module (i.e., when no subfields were selected)
+  * In other words, attributor types (custom or not) will need to include the Attributor::Dumpable module and properly implement the dump instance method to produce the right output with native ruby objects.
+
 
 ## 3.1
 

--- a/lib/praxis-blueprints/renderer.rb
+++ b/lib/praxis-blueprints/renderer.rb
@@ -57,7 +57,7 @@ module Praxis
     def _render(object, fields, view=nil, context: Attributor::DEFAULT_ROOT_CONTEXT)
       if fields == true
         return case object
-        when Attributor::Hash
+        when Attributor::Dumpable
           object.dump
         else
           object
@@ -82,7 +82,7 @@ module Praxis
 
           if subfields == true
             hash[key] = case value
-            when Attributor::Hash
+            when Attributor::Dumpable
               value.dump
             else
               value

--- a/praxis-blueprints.gemspec
+++ b/praxis-blueprints.gemspec
@@ -20,7 +20,7 @@ it results in a structured hash instead of an encoded string. Blueprints can aut
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency(%q<randexp>, ["~> 0"])
-  spec.add_runtime_dependency(%q<attributor>, [">= 4.2"])
+  spec.add_runtime_dependency(%q<attributor>, [">= 5.0.2"])
   spec.add_runtime_dependency(%q<activesupport>, [">= 3"])
 
   spec.add_development_dependency "bundler", "~> 1.6"

--- a/spec/support/spec_blueprints.rb
+++ b/spec/support/spec_blueprints.rb
@@ -22,6 +22,7 @@ class Person < Praxis::Blueprint
     attribute :alive, Attributor::Boolean, default: true
     attribute :myself, Person
     attribute :friends, Attributor::Collection.of(Person)
+    attribute :metadata, Attributor::Hash
   end
 
   view :default do


### PR DESCRIPTION
When fully dumping an object (i.e., when no subfields were selected), that is not a Blueprint, ensure we call `object.dump` if they have the Attributor::Dumpable module.

In other words, attributor types (custom or not) will need to include the `Attributor::Dumpable` module and properly implement the `dump` instance method to produce the right output with native ruby objects.

fixes #26 

Signed-off-by: Josep M. Blanquer <blanquer@rightscale.com>